### PR TITLE
Add Base L2 (mainnet + Sepolia) to Keymap

### DIFF
--- a/src/Keymap.js
+++ b/src/Keymap.js
@@ -35,6 +35,13 @@ const chain = {
       mumbai: 80001
     }
   },
+  base: {
+    id: 3,
+    networks: {
+      mainnet: 8453,
+      sepolia: 84532
+    }
+  },
   mocknet: {
     id: -1,
     networks: {

--- a/src/__tests__/baseRoundtrip.test.js
+++ b/src/__tests__/baseRoundtrip.test.js
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'vitest';
+
+import Encoder from '../Encoder'
+import Decoder from '../Decoder'
+import Keymap from '../Keymap'
+import baseSepoliaProofValue from './baseSepoliaProofValue.json'
+
+describe('Base chain support', () => {
+  test('Keymap exposes base chain with sepolia + mainnet networks', () => {
+    expect(Keymap.chain.base).toBeDefined()
+    expect(Keymap.chain.base.id).toBe(3)
+    expect(Keymap.chain.base.networks.mainnet).toBe(8453)
+    expect(Keymap.chain.base.networks.sepolia).toBe(84532)
+  })
+
+  test('Encoder accepts a blink:base:sepolia:<tx> anchor without throwing', () => {
+    const encoder = new Encoder(baseSepoliaProofValue)
+    const result = encoder.encode()
+
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+    // Multibase base58btc prefix
+    expect(result.startsWith('z')).toBe(true)
+  })
+
+  test('Encoder -> Decoder roundtrip preserves the full proofValue', () => {
+    const encoded = new Encoder(baseSepoliaProofValue).encode()
+    const decoded = new Decoder(encoded).decode()
+
+    expect(decoded).toEqual(baseSepoliaProofValue)
+  })
+
+  test('anchor string round-trips with base:sepolia chain + network prefix', () => {
+    const encoded = new Encoder(baseSepoliaProofValue).encode()
+    const decoded = new Decoder(encoded).decode()
+
+    expect(decoded.anchors).toHaveLength(1)
+    expect(decoded.anchors[0]).toBe(baseSepoliaProofValue.anchors[0])
+    expect(decoded.anchors[0].startsWith('blink:base:sepolia:')).toBe(true)
+  })
+
+  test('base mainnet anchor also round-trips', () => {
+    const mainnetProof = {
+      ...baseSepoliaProofValue,
+      anchors: [
+        'blink:base:mainnet:e80a909ec865513e27e01af27c1599e67406e7d6bcf1280c10e3fb148e5702e0'
+      ]
+    }
+    const encoded = new Encoder(mainnetProof).encode()
+    const decoded = new Decoder(encoded).decode()
+
+    expect(decoded).toEqual(mainnetProof)
+  })
+})

--- a/src/__tests__/baseSepoliaProofValue.json
+++ b/src/__tests__/baseSepoliaProofValue.json
@@ -1,0 +1,11 @@
+{
+  "path": [
+    { "right": "51b4e22ed024ec7f38dc68b0bf78c87eda525ab0896b75d2064bdb9fc60b2698" },
+    { "right": "61c56cca660b2e616d0bd62775e728f50275ae44adf12d1bfb9b9c507a14766b" }
+  ],
+  "merkleRoot": "3c9ee831b8705f2fbe09f8b3a92247eed88cdc90418c024924be668fdc92e781",
+  "targetHash": "c65c6184e3d5a945ddb5437e93ea312411fd33aa1def22b0746d6ecd4aa30f20",
+  "anchors": [
+    "blink:base:sepolia:e80a909ec865513e27e01af27c1599e67406e7d6bcf1280c10e3fb148e5702e0"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds [Base](https://base.org/) to the `Keymap.chain` table so `Encoder` and `Decoder` support anchor strings of the form `blink:base:mainnet:<tx>` and `blink:base:sepolia:<tx>`.

Base is a major Ethereum L2 (operated by Coinbase) that launched on mainnet in August 2023 and has been widely used since. This library currently supports `btc`, `eth`, `mtc` (Polygon), and `mocknet`, so any implementation that wants to anchor MerkleProof2019 proofs on Base today has to pretend it's on `eth:sepolia` (wrong chain ID) or use `mocknet` as a placeholder (loses verifier linkage). Adding Base to the Keymap is a ~12-line change that unblocks real Base anchoring for every implementer.

## Changes

### `src/Keymap.js`

```js
base: {
  id: 3,
  networks: {
    mainnet: 8453,
    sepolia: 84532
  }
},
```

- `id: 3` is the next unused positive integer after `btc=0`, `eth=1`, `mtc=2`. Happy to change this if there's a conflict with an unreleased entry upstream — just let me know.
- `mainnet: 8453` and `sepolia: 84532` are the canonical [Base chain IDs](https://docs.base.org/base-chain/network-information/base-mainnet).

The `Decoder` picks up the new chain automatically via its existing `invertBy(Keymap.chain, value => value.id)` inversion — no separate decoder change needed.

### `src/__tests__/baseRoundtrip.test.js` + `baseSepoliaProofValue.json`

Five new tests covering:

- Keymap exposes `base` with the correct chain id and networks
- `Encoder` accepts `blink:base:sepolia:<tx>` without throwing
- Encoder → Decoder roundtrip preserves the full proofValue
- Anchor string roundtrips with the `blink:base:sepolia:` prefix intact
- Base mainnet anchor also roundtrips

Existing 21 tests still pass; **26 total, all green**.

## Test output

\`\`\`
 Test Files  4 passed (4)
      Tests  26 passed (26)
\`\`\`

## Motivation

Discovered while implementing MerkleProof2019 issuance in TypeScript for [LearnCoin](https://github.com/barcelova/LearnCoin), a credentialing infrastructure project that anchors its Blockcerts v3 proofs on Base L2. Without this entry, our spike had to use `blink:mocknet:mocknet:<tx>` as a placeholder and lost the chain-linked verification story; adding Base to the Keymap resolves that cleanly without any downstream changes.

This is one of two upstream contributions from LearnCoin landing simultaneously against the Blockcerts ecosystem — the other is [blockchain-certificates/cert-schema#95](https://github.com/blockchain-certificates/cert-schema/pull/95) fixing a protected-term conflict between the v3-beta JSON-LD context and OB 3.0.

## Backwards compatibility

Fully backwards compatible:

- No existing chain entries are modified
- No existing term definitions are renamed
- No test fixtures are changed
- New chain id (3) is additive; implementations that don't know about `base` continue to work unchanged

Happy to iterate on the chain id number, the test structure, or the anchor format if you'd prefer a different approach.